### PR TITLE
fix doi matching on a sciencedirect record page: doi.org and no more dx.doi.org

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -18,7 +18,7 @@ ISTEXLinkInserter = {
   openURLPrefix : 'https://api.istex.fr/document/openurl?',
 
   // DOI pattern
-  doiPattern                 : /\/\/(dx\.doi\.org|doi\.acm\.org|dx\.crossref\.org).*\/(10\..*(\/|%2(F|f)).*)/,
+  doiPattern                 : /\/\/(doi\.org|dx\.doi\.org|doi\.acm\.org|dx\.crossref\.org).*\/(10\..*(\/|%2(F|f)).*)/,
   // the index of the group where to find the DOI
   doiGroup                   : 2,
   regexDoiPatternConservative: new RegExp('(10\\.\\d{4,5}\\/[\\S]+[^;,.\\s])', 'gi'),
@@ -238,7 +238,8 @@ ISTEXLinkInserter = {
       if (simpleHref.match(this.doiPattern)) {
         mask = this.flags.SCOPUS_DOI;
       }
-    } else if ((href.indexOf('dx.doi.org') !== -1 ||
+    } else if ((href.indexOf('doi.org') !== -1 ||
+                href.indexOf('dx.doi.org') !== -1 ||
                 href.indexOf('doi.acm.org') !== -1 ||
                 href.indexOf('dx.crossref.org') !== -1)
                && href.match(this.doiPattern)) {


### PR DESCRIPTION
Example on this page:
http://www.sciencedirect.com/science/article/pii/S0940299397800784

Now we have this kind of url:
https://doi.org/10.1016/S0940-2993(97)80078-4

In the past it was:
https://dx.doi.org/10.1016/S0940-2993(97)80078-4