### PR TITLE
ignore <style> tag

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -44,7 +44,8 @@ const forbidenElements = ['applet',
                           'g',
                           'path',
                           'text',
-                          'rect'];
+                          'rect',
+			  'style'];
 
 config = {
   istexBaseURL: 'api.istex.fr/document/openurl',


### PR DESCRIPTION
Add the <style> tag in the blacklisted tags. 

Reason: some sites are actually injecting some styling via a <style> element, e.g. 
https://scite.ai/reports/10.1038/nature09144
the ISTEX extension rewrites the content of the style element because it has a doi, and the highlight disappears. 